### PR TITLE
Refatoração: Implementação do Mapper e DTO para o Shinobi

### DIFF
--- a/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiController.java
+++ b/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiController.java
@@ -23,8 +23,8 @@ public class ShinobiController {
     @PostMapping("/adicionar") //enviar informação passada pelo método
     //RequestBody envia requisições pelo corpo do conteúdo
     //Desearalização(Da web para o Banco de Dados)
-    public ShinobiModel adicionarShinobi(@RequestBody ShinobiModel shinobi) {
-        return shinobiService.adicionarShinobi(shinobi);
+    public ShinobiDTO adicionarShinobi(@RequestBody ShinobiDTO shinobiDTO) {
+        return shinobiService.adicionarShinobi(shinobiDTO);
     }
 
     //Procurar Shinobi por ID

--- a/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiController.java
+++ b/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiController.java
@@ -29,19 +29,19 @@ public class ShinobiController {
 
     //Procurar Shinobi por ID
     @GetMapping("/exibirPorID/{id}") //ID será passada pelo usuário
-    public ShinobiModel exibirShinobiPorID(@PathVariable Long id) {
+    public ShinobiDTO exibirShinobiPorID(@PathVariable Long id) {
         return shinobiService.exibirShinobiPorID(id);
     }
 
     //Exibir todos os Shinobis
     @GetMapping("/listar")
-    public List<ShinobiModel> listarShinobis() {
+    public List<ShinobiDTO> listarShinobis() {
         return shinobiService.listarShinobis();
     }
 
     //Atualizar Shinobi
     @PutMapping("/atualizar/{id}") //atualizar informação passada pelo método
-    public ShinobiModel atualizarShinobi(@PathVariable Long id, @RequestBody ShinobiModel shinobiAtualizado) {
+    public ShinobiDTO atualizarShinobi(@PathVariable Long id, @RequestBody ShinobiDTO shinobiAtualizado) {
         return shinobiService.atualizar(id, shinobiAtualizado);
     }
 

--- a/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiDTO.java
+++ b/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiDTO.java
@@ -1,4 +1,20 @@
 package com.github.lucasdevrj.cadastrodeshinobi.shinobi;
 
+import com.github.lucasdevrj.cadastrodeshinobi.missao.MissaoModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ShinobiDTO {
+
+    private Long id;
+    private String nome;
+    private String email;
+    private String imagemUrl;
+    private int idade;
+    private String rank;
+    private MissaoModel missao;
 }

--- a/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiDTO.java
+++ b/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiDTO.java
@@ -1,0 +1,4 @@
+package com.github.lucasdevrj.cadastrodeshinobi.shinobi;
+
+public class ShinobiDTO {
+}

--- a/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiMapper.java
+++ b/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiMapper.java
@@ -1,0 +1,4 @@
+package com.github.lucasdevrj.cadastrodeshinobi.shinobi;
+
+public class ShinobiMapper {
+}

--- a/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiMapper.java
+++ b/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiMapper.java
@@ -1,4 +1,36 @@
 package com.github.lucasdevrj.cadastrodeshinobi.shinobi;
 
+//Classe para mapear/juntar as classes Model com a DTO
+//Pois assim adicionamos mais uma camada de abstração ao Banco de Dados da aplicação
+//Dará mais segurança a aplicação
+
+import org.springframework.stereotype.Component;
+
+@Component
 public class ShinobiMapper {
+
+    public ShinobiModel map(ShinobiDTO shinobiDTO) {
+        ShinobiModel shinobiModel = new ShinobiModel();
+        shinobiModel.setId(shinobiDTO.getId());
+        shinobiModel.setNome(shinobiDTO.getNome());
+        shinobiModel.setEmail(shinobiDTO.getEmail());
+        shinobiModel.setImagemUrl(shinobiDTO.getImagemUrl());
+        shinobiModel.setRank(shinobiDTO.getRank());
+        shinobiModel.setIdade(shinobiDTO.getIdade());
+        shinobiModel.setMissao(shinobiDTO.getMissao());
+        return shinobiModel;
+    }
+
+    public ShinobiDTO map(ShinobiModel shinobiModel) {
+        ShinobiDTO shinobiDTO = new ShinobiDTO();
+        shinobiDTO.setId(shinobiModel.getId());
+        shinobiDTO.setNome(shinobiModel.getNome());
+        shinobiDTO.setEmail(shinobiModel.getEmail());
+        shinobiDTO.setImagemUrl(shinobiModel.getImagemUrl());
+        shinobiDTO.setRank(shinobiModel.getRank());
+        shinobiDTO.setIdade(shinobiModel.getIdade());
+        shinobiDTO.setMissao(shinobiModel.getMissao());
+        return shinobiDTO;
+    }
+
 }

--- a/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiModel.java
+++ b/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiModel.java
@@ -30,6 +30,9 @@ public class ShinobiModel {
     @Column(name = "idade")
     private int idade;
 
+    @Column(name = "rank")
+    private String rank;
+
     @ManyToOne //muitos ninjas podem fazer uma missão
     @JoinColumn(name = "missoes_id") //chave estrangeira
     private MissaoModel missao;

--- a/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiService.java
+++ b/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiService.java
@@ -9,9 +9,11 @@ import java.util.Optional;
 public class ShinobiService {
 
     private ShinobiRepository shinobiRepository;
+    private ShinobiMapper shinobiMapper;
 
-    public ShinobiService(ShinobiRepository shinobiRepository) {
+    public ShinobiService(ShinobiRepository shinobiRepository, ShinobiMapper shinobiMapper) {
         this.shinobiRepository = shinobiRepository;
+        this.shinobiMapper = shinobiMapper;
     }
 
     public List<ShinobiModel> listarShinobis() {
@@ -23,8 +25,10 @@ public class ShinobiService {
         return shinobiBuscadoPorID.orElse(null);
     }
 
-    public ShinobiModel adicionarShinobi(ShinobiModel shinobi) {
-        return shinobiRepository.save(shinobi);
+    public ShinobiDTO adicionarShinobi(ShinobiDTO shinobiDTO) {
+        ShinobiModel shinobi =  shinobiMapper.map(shinobiDTO);
+        shinobi = shinobiRepository.save(shinobi);
+        return shinobiMapper.map(shinobi);
     }
 
     //tem que ser uma função void, pois não será necessário mandar nada ao servidor

--- a/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiService.java
+++ b/src/main/java/com/github/lucasdevrj/cadastrodeshinobi/shinobi/ShinobiService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class ShinobiService {
@@ -16,15 +17,22 @@ public class ShinobiService {
         this.shinobiMapper = shinobiMapper;
     }
 
-    public List<ShinobiModel> listarShinobis() {
-        return shinobiRepository.findAll();
+    //Convertendo de Model para DTO
+    //Retornando a lista de shinobis com DTO
+    public List<ShinobiDTO> listarShinobis() {
+        List<ShinobiModel> shinobis = shinobiRepository.findAll();
+        return shinobis.stream()
+                .map(shinobiMapper::map)
+                .collect(Collectors.toList());
     }
 
-    public ShinobiModel exibirShinobiPorID(Long id) {
+    public ShinobiDTO exibirShinobiPorID(Long id) {
         Optional<ShinobiModel> shinobiBuscadoPorID = shinobiRepository.findById(id);
-        return shinobiBuscadoPorID.orElse(null);
+        return shinobiBuscadoPorID.map(shinobiMapper::map).orElse(null);
     }
 
+    //transferindo de Model para DTO, assim tendo mais segurança na aplicação
+    //salvando o ninja no banco de dados através do repository
     public ShinobiDTO adicionarShinobi(ShinobiDTO shinobiDTO) {
         ShinobiModel shinobi =  shinobiMapper.map(shinobiDTO);
         shinobi = shinobiRepository.save(shinobi);
@@ -32,14 +40,18 @@ public class ShinobiService {
     }
 
     //tem que ser uma função void, pois não será necessário mandar nada ao servidor
+    //não é preciso transferir de DTO para Model, pois é passado somente um querie SQL para deleção
     public void deletarShinobiPorID(Long id) {
         shinobiRepository.deleteById(id);
     }
 
-    public ShinobiModel atualizar(Long id, ShinobiModel shinobiAtualizado) {
-        if (shinobiRepository.existsById(id)) {
+    public ShinobiDTO atualizar(Long id, ShinobiDTO shinobiDTO) {
+        Optional<ShinobiModel> shinobiExistente = shinobiRepository.findById(id);
+        if (shinobiExistente.isPresent()) {
+            ShinobiModel shinobiAtualizado = shinobiMapper.map(shinobiDTO);
             shinobiAtualizado.setId(id);
-            return shinobiRepository.save(shinobiAtualizado);
+            ShinobiModel shibobiSalvo = shinobiRepository.save(shinobiAtualizado);
+            return shinobiMapper.map(shibobiSalvo);
         }
         return null;
     }


### PR DESCRIPTION
Alterações propostas pela PR

Implementação do ShinobiMapper para conversão entre ShinobiModel e ShinobiDTO.
Criação do ShinobiDTO contendo os campos necessários para comunicação externa.
Refatoração do ShinobiService para utilizar o ShinobiDTO, eliminando a exposição direta ao Shinobi Model.
Ajustes no ShinobiController para trabalhar com o ShinobiDTO, garantindo a estrutura mais coesa e desaclopada.

Essas mudanças visam melhorar a organização do código e a separação de responsabilidades, facilitando a manutenção e expansão futura da aplicação. 